### PR TITLE
Update uploader.js

### DIFF
--- a/src/js/uploader.js
+++ b/src/js/uploader.js
@@ -279,8 +279,14 @@
                         var renameFile = function() {
                             if(filename !== undefined && filename !== null && filename !== '') {
                                 var ext = file.ext;
-                                if(ext.length && !options.renameExtension && filename.lastIndexOf('.' + ext) !== (filename.length - ext.length - 1)) {
-                                    filename += '.' + ext;
+                                if(ext.length && !options.renameExtension) {
+                                    var index_ = filename.lastIndexOf('.');
+                                	if(index_ == -1){
+                                		filename += '.' + ext;
+                                	}else{
+                                		var ext_new = filename.substring(index_,filename.length);
+                                		if(ext_new != ext)filename = filename.substring(0,index_)+"."+ext;
+                                	} 
                                 }
                                 file.name = filename;
                             }


### PR DESCRIPTION
修改文件名，但不允许修改扩展名的判断逻辑有些问题，当修改后的文件名（新名称中没有加扩展名的情况下）与文件原扩展名长度相同时，出现修改后扩展名丢失问题。