### PR TITLE
gulp构建文件中对于babel的引用错误

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -343,7 +343,7 @@ function buildBundle(name, callback, type) {
         gulp.task('build:' + name + ':js', function () {
             var destPath = getBuildPath(build, 'js');
             var gulpPipe = gulp.src(source.js);
-            if (build.babel) {
+            if (babel) {
                 gulpPipe = gulpPipe.pipe(babel({
                     presets: ['babel-preset-env']
                 }));


### PR DESCRIPTION
现象为：构建出的代码包含const修饰的变量，不能在ie8上运行
解决：通过Debug gulp file 发现编译过程并没有使用Babel，修改掉babel的引用即可