### PR TITLE
- tree: remove the dead caret variables

### DIFF
--- a/lib/tree/src/style/tree.css
+++ b/lib/tree/src/style/tree.css
@@ -6,8 +6,6 @@
 /* Toggle icon. */
 .tree-toggle {
   @apply -w-4 -flex -items-center -justify-center -rounded -h-4 -flex-none --mr-1.5;
-  --caret-size: 5px;
-  --caret-opacity: .3;
 }
 
 /* Hover effection. */


### PR DESCRIPTION
Removes two dead CSS custom properties from `lib/tree`.

`.tree-toggle` sets `--caret-size: 5px` and `--caret-opacity: .3`. Both were live when written — `5589a6d337` (2023-06-15) and `13ee4449eb` (2023-06-30, *"tree: change toggle icon opacity"*) — back when the shared caret rule in `@zui/css-icons` read them:

```css
.caret, .caret-down, .caret-left, .caret-right, .caret-up {
    border: var(--caret-size, 4px) solid transparent;   /* the triangle */
    opacity: var(--caret-opacity, .5);
}
```

`aaf34e96dd` (2024-03-24, *"css-icons: change caret shape from angle to chevron"*) replaced that rule with a chevron built from fixed utilities and dropped **both** `var()` reads, orphaning the pair in a single commit. Neither has been read since.

After this change `grep -rn -- '--caret-size' lib exts` returns nothing, and `--caret-opacity` is left declared only at `:root` in `@zui/css-icons`.

## Why this is rendering-neutral

A custom property that nothing substitutes has no effect, but the claim was verified rather than asserted:

- Before/after full-page screenshots of `/tree/` are **byte-identical** (sha256 `b783aa19…`), which is stronger than a zero pixel diff.
- Not a stale-cache artifact: the after-probe reads both properties as unset where the before-probe read `5px` and `.3`, so the dev server had genuinely reloaded the stylesheet.
- Page state unchanged — 6 trees, 24 `.tree-toggle`, 4 `.caret-down` at opacity 1, 0 console errors.

## Relationship to #242

#242 restores the at-rest caret opacity that the same 2024 commit dropped, so it is the PR that makes `--caret-opacity` meaningful again — as a `:root` default of `.5` for every caret, rather than a per-lib override.

The two PRs are independent and touch disjoint files. Merging **this one first** is preferable: on #242's branch alone, tree's surviving `.3` override makes its carets render at `0.3` while every other caret sits at `0.5`. Once both land, tree matches the rest at `0.5`. Nothing breaks in the other order; it is only a transient.

Why `.3` is not carried forward is covered in #242 — briefly, the value was tuned for the old filled triangle and reads far too faint on the 1px chevron that replaced it.

## Validation

`pnpm lint`, `pnpm typecheck`, `pnpm check` (9 test files / 60 tests, 4 skills tests) and `pnpm build -- --lib=tree --noMinify` all green, with the emitted CSS inspected.

## Note for review

CI on this repo is currently failing for every PR with *"The job was not started because your account is locked due to a billing issue"* — unrelated to this change.
