### PR TITLE
* css-icons: restore the caret opacity at rest

### DIFF
--- a/lib/css-icons/docs/lib/icons/index.md
+++ b/lib/css-icons/docs/lib/icons/index.md
@@ -32,27 +32,31 @@ ZUI 提供一组用纯 CSS 绘制的小图标，不依赖图标字体，也不�
 
 :::
 
-放在带有 `.disabled` 或 `.readonly` 的元素内时，下拉图标会按 `--caret-opacity` 变淡。
+下拉图标默认以 `--caret-opacity`（`.5`）显示，比正文更淡，作为次要元素出现。在任意祖先元素上覆盖 `--caret-opacity` 即可调整其中所有下拉图标的深浅。
 
 ::: tabs
 
 == 示例
 
 <Example class="flex items-center gap-4">
-  <span class="row items-center gap-1">正常 <span class="caret"></span></span>
+  <span class="row items-center gap-1">默认 <span class="caret"></span></span>
+  <span class="row items-center gap-1" style="--caret-opacity: 1">加深 <span class="caret"></span></span>
+  <span class="row items-center gap-1" style="--caret-opacity: .3">变淡 <span class="caret"></span></span>
   <span class="row items-center gap-1 disabled">禁用 <span class="caret"></span></span>
-  <span class="row items-center gap-1 readonly">只读 <span class="caret"></span></span>
 </Example>
 
 == HTML
 
 ```html
-<span class="row items-center gap-1">正常 <span class="caret"></span></span>
+<span class="row items-center gap-1">默认 <span class="caret"></span></span>
+<span class="row items-center gap-1" style="--caret-opacity: 1">加深 <span class="caret"></span></span>
+<span class="row items-center gap-1" style="--caret-opacity: .3">变淡 <span class="caret"></span></span>
 <span class="row items-center gap-1 disabled">禁用 <span class="caret"></span></span>
-<span class="row items-center gap-1 readonly">只读 <span class="caret"></span></span>
 ```
 
 :::
+
+`.disabled` 和 `.readonly` 不会额外调暗下拉图标，它们的作用是把图标的不透明度固定在 `--caret-opacity` 上：`@zui/utilities` 的 `.disabled *` 会把容器内所有元素改成 `--opacity-disabled`，若不固定，禁用容器里的下拉图标反而会比正常状态更明显。禁用容器本身的整体变淡仍然生效。
 
 ## V 形
 
@@ -370,8 +374,8 @@ CSS 图标提供了如下 CSS 类：
 | `arrow-right` | 修饰类 | 与 `arrow` 搭配使用，尖角朝右并贴在父元素右边 |
 | `is-collapsed` | 修饰类 | 放在 `toggle-icon` 的祖先元素上，使其显示为加号 |
 | `is-expanded` | 修饰类 | 放在 `toggle-icon` 的祖先元素上，使其显示为减号 |
-| `disabled` | 修饰类 | 放在 `caret` 的祖先元素上，使下拉图标按 `--caret-opacity` 变淡 |
-| `readonly` | 修饰类 | 放在 `caret` 的祖先元素上，使下拉图标按 `--caret-opacity` 变淡 |
+| `disabled` | 修饰类 | 放在下拉图标的祖先元素上，把图标的不透明度固定为 `--caret-opacity` |
+| `readonly` | 修饰类 | 放在下拉图标的祖先元素上，把图标的不透明度固定为 `--caret-opacity` |
 
 ## CSS 变量
 
@@ -379,10 +383,10 @@ CSS 图标提供了如下 CSS 变量：
 
 | 变量名称 | 变量含义 | 默认值 | 声明位置 |
 | --- | --- | --- | --- |
-| `--caret-opacity` | 处于 `disabled` 或 `readonly` 元素内的下拉图标的不透明度 | `.5` | `:root` |
+| `--caret-opacity` | 下拉图标的不透明度 | `.5` | `:root` |
 | `--toggle-icon-size` | 切换图标的边长 | `calc((var(--font-size-root) * 3 / 4) + 1px)` | `:root` |
 | `--arrow-size` | 气泡尖角的大小 | `5px` | `.arrow` |
 
-`--caret-opacity` 与 `--toggle-icon-size` 声明在 `:root` 上，图标从祖先元素继承它们的值，因此既可以在 `:root` 上全局覆盖，也可以在任意祖先元素上局部覆盖。`@zui/tree` 就是在 `.tree-toggle` 上把 `--caret-opacity` 改成 `.3` 的。
+`--caret-opacity` 与 `--toggle-icon-size` 声明在 `:root` 上，图标从祖先元素继承它们的值，因此既可以在 `:root` 上全局覆盖，也可以在任意祖先元素上局部覆盖，例如在某个工具栏上把其中的下拉图标整体加深。
 
 `--arrow-size` 声明在 `.arrow` 自身上，继承而来的值不会生效，需要覆盖到图标元素本身，例如行内 `style` 或更具体的选择器。

--- a/lib/css-icons/src/icons/caret.css
+++ b/lib/css-icons/src/icons/caret.css
@@ -1,5 +1,6 @@
 :root {
-    /* Opacity of a caret inside a disabled or readonly element. */
+    /* Opacity of a caret at rest. Set it on any ancestor to dim or brighten
+       the carets inside it. */
     --caret-opacity: .5;
 }
 
@@ -9,6 +10,7 @@
 .caret-down,
 .caret-up {
   @apply -w-[0.75rem] -h-[0.75rem] -relative -inline-flex -items-center -justify-center;
+  opacity: var(--caret-opacity);
 }
 .caret::before,
 .caret-left::before,
@@ -27,7 +29,18 @@
   @apply -rotate-[225deg] -translate-y-0.5;
 }
 
+/* Pin the opacity against `.disabled *`, which would otherwise raise a caret in a
+   disabled container to `--opacity-disabled`, and against consumer rules that
+   override the base opacity at a single class of specificity. */
 .disabled .caret,
-.readonly .caret {
+.disabled .caret-left,
+.disabled .caret-right,
+.disabled .caret-down,
+.disabled .caret-up,
+.readonly .caret,
+.readonly .caret-left,
+.readonly .caret-right,
+.readonly .caret-down,
+.readonly .caret-up {
     opacity: var(--caret-opacity);
 }


### PR DESCRIPTION
> **Stacked on #240.** Base branch is `dev_optimize_css_libs`, so this PR's diff shows only the caret work. It will need retargeting to `dev_optimize` if #240's branch is not deleted on merge.

Three defects, all left behind by one commit.

`aaf34e96dd` (2024-03-24, *"css-icons: change caret shape from angle to chevron"*) rewrote the shared caret rule. Before it:

```css
.caret, .caret-down, .caret-left, .caret-right, .caret-up {
    @apply -w-0 -h-0 -inline-block;
    border: var(--caret-size, 4px) solid transparent;   /* the triangle */
    opacity: var(--caret-opacity, .5);                  /* all five variants */
}
```

The reshape kept the geometry and dropped **both** `var()` reads. The commit message describes a shape change and nothing else.

| # | Defect |
| --- | --- |
| F-1 | `@zui/tree` set `--caret-opacity: .3` on `.tree-toggle` (`13ee4449eb`, 2023-06-30, *"change toggle icon opacity"*). Live and visible when written; dead since the reshape. |
| F-2 | Carets stopped dimming at rest **everywhere** — 71 of them, all at `opacity: 1`, where the default had been `.5`. |
| F-3 | `.disabled .caret` / `.readonly .caret` silently lost coverage of the four directional variants. It targeted bare `.caret` only, which was correct while the shared rule carried the default for all five. |

This PR fixes F-2 and F-3, in `@zui/css-icons` only. F-1 — tree's dead override — is removed in **#241**, which touches no file this PR touches.

Restores `opacity: var(--caret-opacity)` on the shared five-variant rule, so `--caret-opacity` now means the at-rest opacity, and extends the `.disabled` / `.readonly` rule to all five variants.

**Why tree's `.3` is not revived** (implemented in #241): it was tuned in 2023 for the old caret — a filled 4px triangle. The chevron that replaced it is a 1px stroke, and the same number reads far lighter on it. Rendered side by side in both themes, `.3` on the chevron is faint enough to read as disabled rather than secondary, which is the wrong signal for a tree expander. Tree toggles should use the `.5` default like every other caret.

**Why the `.disabled` rule is not redundant** with the restored default: `@zui/utilities` applies `.disabled * {opacity: var(--opacity-disabled)}` at the same specificity as the base caret rule. Without pinning, a caret inside a disabled container would resolve to `.7` — *brighter* than the `.5` it shows when enabled.

## Measurements

Before, injecting all five variants into a wrapper:

| wrapper | `.caret` | directional variants |
| --- | --- | --- |
| none | 1 | 1 |
| `.disabled` | 0.5 | **0.7** |
| `.readonly` | 0.5 | **1** |

After — every variant identical in every state:

| wrapper | all five |
| --- | --- |
| none | 0.5 |
| `.disabled` | 0.5 (× 0.7 container = 0.35 effective) |
| `.readonly` | 0.5 |
| ancestor sets `--caret-opacity: .9` | 0.9 |

Re-tallied across the consumer dev pages, matching batch 4's census exactly — 71 carets, zero console errors:

| lib | n | opacity on this branch |
| --- | --- | --- |
| `picker` | 11 | 0.5 |
| `dropdown` | 22 | 0.5 |
| `nav` | 27 | 0.5 |
| `menu` | 7 | 0.5 |
| `tree` | 4 | **0.3** — tree's own override still present here |

Tree reads `0.3` on this branch alone because its `--caret-opacity: .3` survives until #241 lands; with both merged, all 71 sit at `0.5`. **Merging #241 first avoids that transient**, though nothing breaks in the other order.

Docs page demo verified on the built site: `0.5` default, `1` and `0.3` via ancestor override, disabled pinned at `0.5` inside a `0.7` container.

## Rendering impact

This is a deliberate visual change: **every caret in the product goes from fully opaque to `.5`**. That is the point of the PR — restoring a design the 2024 reshape dropped by accident — but it is the one item in this follow-up wave that is not rendering-neutral, and it deserves a look rather than a rubber stamp.

## Validation

`pnpm lint`, `pnpm typecheck`, `pnpm check` (9 test files / 60 tests, 4 skills tests), `pnpm build -- --lib=css-icons --noMinify`, `pnpm docs:prepare -- --copy` and `pnpm docs:build` all green.

CI on this repo is currently failing for every PR with *"The job was not started because your account is locked due to a billing issue"* — unrelated to this change.
