### PR TITLE
+ proj: whitelist the published source files in seven libs

### DIFF
--- a/lib/avatar/package.json
+++ b/lib/avatar/package.json
@@ -18,6 +18,9 @@
         "./css": "./src/main-css.ts",
         "./react": "./src/main-react.ts"
     },
+    "files": [
+        "./src/**/*"
+    ],
     "zui": {
         "type": "component",
         "displayName": "头像",

--- a/lib/form/package.json
+++ b/lib/form/package.json
@@ -12,6 +12,9 @@
         "@zui/button": "workspace:*",
         "@zui/utilities": "workspace:*"
     },
+    "files": [
+        "./src/**/*"
+    ],
     "zui": {
         "type": "control",
         "displayName": "表单",

--- a/lib/icons/package.json
+++ b/lib/icons/package.json
@@ -13,6 +13,9 @@
         "@zui/base": "workspace:*",
         "@zui/utilities": "workspace:*"
     },
+    "files": [
+        "./src/**/*"
+    ],
     "zui": {
         "type": "control",
         "displayName": "图标",

--- a/lib/icons/package.json
+++ b/lib/icons/package.json
@@ -14,7 +14,8 @@
         "@zui/utilities": "workspace:*"
     },
     "files": [
-        "./src/**/*"
+        "./src/**/*",
+        "./public/**/*"
     ],
     "zui": {
         "type": "control",

--- a/lib/input-control/package.json
+++ b/lib/input-control/package.json
@@ -16,6 +16,9 @@
         "@zui/icons": "workspace:0.0.1",
         "@zui/utilities": "workspace:*"
     },
+    "files": [
+        "./src/**/*"
+    ],
     "zui": {
         "type": "control",
         "displayName": "输入框",

--- a/lib/input-group/package.json
+++ b/lib/input-group/package.json
@@ -19,6 +19,9 @@
         "@zui/checkbox": "workspace:^0.0.1",
         "@zui/utilities": "workspace:*"
     },
+    "files": [
+        "./src/**/*"
+    ],
     "zui": {
         "type": "component",
         "displayName": "输入组",

--- a/lib/upload-imgs/package.json
+++ b/lib/upload-imgs/package.json
@@ -25,6 +25,9 @@
     "devDependencies": {
         "zui-dev": "workspace:^0.0.1"
     },
+    "files": [
+        "./src/**/*"
+    ],
     "zui": {
         "type": "component",
         "displayName": "上传图片",

--- a/lib/upload/package.json
+++ b/lib/upload/package.json
@@ -24,6 +24,9 @@
     "devDependencies": {
         "zui-dev": "workspace:^0.0.1"
     },
+    "files": [
+        "./src/**/*"
+    ],
     "zui": {
         "type": "component",
         "displayName": "上传文件",


### PR DESCRIPTION
`.agents/skills/zui-standards/references/library.md:29` mandates
`"files": ["./src/**/*"]` on every lib. Without it, a pack ships whatever sits in the lib
directory — `dev.ts`, `docs/`, stray local files — alongside the sources consumers import.

Seven libs had no `files` field: `avatar`, `form`, `icons`, `input-control`,
`input-group`, `upload`, `upload-imgs`. With #240's three, that closes the gap.

## Commits

1. **the whitelist** — one 3-line block per manifest, 7 files.
2. **`@zui/icons` fonts** — that whitelist was too narrow for one lib.

## The icons fix

`./src/**/*` excludes `lib/icons/public/`, which holds the ZenIcon binaries that
`src/style/icons-core.css:3-7` loads via `@font-face` as `@/public/zenicon.{eot,woff,ttf,svg}`
— referenced through the lib-root alias, which is why a search for relative `../public`
paths does not find it. It also excluded `public/fontawesome-license.md`, which should
ship on its own merits.

This governs no publish **today**: `scripts/build/publish.ts` ships a single aggregate
package built from `dist/zui`, so the individual workspace packages are never published,
and `scripts/build/config.ts:425-428` copies each lib's `public/` from the working tree
regardless of `files`. But the manifest is the wrong place to leave a trap that only
springs if per-lib publishing is ever turned on — especially one that looks more correct
than it is.

`@zui/icons` is the only lib affected. A scan of every lib carrying a `files` whitelist
finds it is the only one whose `src/` references a path outside `src/`; the `public/` and
`assets/` directories in `dashboard`, `sortable`, `avatar` and `modal` hold demo and
vendor files that nothing in `src/` loads.

## Verification

- **Edits are surgical.** Each manifest was round-tripped through a JSON parse and checked
  for unchanged key order and unchanged values for every key but `files`. The first commit
  is exactly 21 insertions, 0 deletions.
- **Measured, not assumed.** `npm pack --dry-run` on `@zui/avatar`: **29 files → 15**,
  dropping `dev.ts`, `docs/`, `tsconfig.json` and 140 kB of `assets/*.png`. `README.md`
  stays — npm always includes it and `files` cannot exclude it.
- `@zui/icons` now packs 11 files: the manifest, README, four src files and the five under
  `public/`. `dev.ts`, `docs/` and the IcoMoon sources in `assets/` stay excluded.
- `pnpm check` green; full `pnpm build` green, 870 modules, every lib still resolving.

## Placement

The plan called for the field "after `devDependencies`, before `zui`". There is no such
convention in this repo — key order varies widely, and the dominant shape among libs that
already have the field is `keywords → files → exports → dependencies → devDependencies →
zui`. The rule actually applied is the one stable one: **insert immediately before
`"zui"`**.

Two of the seven (`avatar`, `form`) also carry no `keywords` field. That is #246's scope,
untouched here; the two PRs overlap on five manifests but edit different regions and merge
cleanly.
