### PR TITLE
+ utilities: load the button lib on the dev page

### DIFF
--- a/lib/utilities/README.md
+++ b/lib/utilities/README.md
@@ -698,10 +698,6 @@
 .blocks > h3 {
   width: 100%;
 }
-.blocks > .btn {
-  padding: 0 0.75rem;
-  height: 2rem;
-}
 </style>
 
 ### Animations

--- a/lib/utilities/dev.ts
+++ b/lib/utilities/dev.ts
@@ -1,0 +1,2 @@
+import '@zui/button';
+import './src/main';

--- a/lib/utilities/package.json
+++ b/lib/utilities/package.json
@@ -6,6 +6,7 @@
     "main": "src/main.ts",
     "devDependencies": {
         "@zui/base": "workspace:*",
+        "@zui/button": "workspace:^0.0.1",
         "@zui/core": "workspace:^0.0.1"
     },
     "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1674,6 +1674,9 @@ importers:
       '@zui/base':
         specifier: workspace:*
         version: link:../base
+      '@zui/button':
+        specifier: workspace:^0.0.1
+        version: link:../button
       '@zui/core':
         specifier: workspace:^0.0.1
         version: link:../core


### PR DESCRIPTION
Follow-up B out of #240, whose follow-up list read: "`dev.ts` is missing from 6 further libs (`base`, `breadcrumb`, `button`, `checkbox`, `form-control`, `utilities`)."

**That list was wrong.** A missing `dev.ts` is not a defect on its own — `scripts/dev/config-server.ts:133-135` falls back to `src/main.ts`, so a lib's own styles always load. `dev.ts` matters only when a playground needs a *demo dependency*. Measured on the dev server:

| lib | `.btn` on its dev page | verdict |
| --- | --- | --- |
| `base`, `breadcrumb`, `checkbox`, `form-control` | 0 | nothing foreign to load — not a gap |
| `button` | 109, styled | its own lib — not a gap |
| `utilities` | 7, **unstyled** | real gap |

Five of the six were phantom. This PR is the one that survives.

## The defect

`config-server.ts:145` skips the automatic `@zui/utilities` injection for `utilities` itself, and the lib had no `dev.ts`. So `@zui/button` never loaded, and the seven `<button class="btn">` examples that `README.md:11-16,31` uses to demonstrate `state` / `active` / `selected` / `disabled` rendered with a transparent background and no radius — exactly what those examples exist to show.

`README.md:701-704` also carried a `.blocks > .btn {padding: 0 0.75rem; height: 2rem}` rule in its inline `<style>`, hand-faking the geometry. Those values are precisely what the real lib applies (`btn.css:2` → `-px-3`, `-h-[--btn-height]`; `vars.css:5` → `--btn-height: 2rem`), so it is a workaround, and it would fight `--btn-height` for any sized button.

## After

| example | height | background | radius | `::before` |
| --- | --- | --- | --- | --- |
| `btn` | 32px | `rgb(241,245,249)` | 4px | 0 |
| `btn active` | 32px | `rgb(241,245,249)` | 4px | **1** |
| `btn selected` | 32px | `rgb(241,245,249)` | 4px | **0.1** |
| `btn primary` | 32px | `rgb(59,130,246)` | 4px | 0 |
| `btn primary active` | 32px | `rgb(59,130,246)` | 4px | 1, overlay `rgba(0,0,0,.1)` |
| `btn primary selected` | 32px | `rgb(59,130,246)` | 4px | 0.1, overlay `rgba(255,255,255,.1)` |
| `btn [disabled]` | 32px | `rgb(241,245,249)` | 4px | `display: none`, opacity .7, cursor `not-allowed` |

Before: transparent background, radius 0, `--btn-height` unset. The state effect is painted on `::before` (`state.css`), not the element background, which is where the `active` / `selected` distinction lives. 0 console errors.

## Known cost: workspace dependency cycles

Declaring `@zui/button` closes a loop, because `utilities` is the base CSS layer `button` builds on. The workspace goes from **0 cycles to 3**:

```
avatar <-> button <-> utilities
button <-> icons  <-> utilities
button <-> utilities
```

`pnpm install` now prints `[WARN] There are cyclic workspace dependencies: lib/avatar, lib/utilities, lib/button` on every run. Confirmed absent on `dev_optimize` before this change.

This was a deliberate choice. `vite.shared.ts:66` aliases `@zui/*` to `lib/*` unconditionally, so `dev.ts` resolves `@zui/button` with or without the declaration — the page renders identically either way, measured. Declaring it keeps the manifest honest and matches `label`, `form` and `table`, which all declare `@zui/button` for exactly this purpose. All the edges are devDependencies.

## Lockfile

Hand-patched with only the `lib/utilities` → `@zui/button` link (+3 lines), then `pnpm install --frozen-lockfile`, which accepted it with no drift. A bare `pnpm install` on this repo resolves unrelated floating ranges to newer versions — 35 packages are currently behind, several by a major.

## Validation

`pnpm check` green (lint, typecheck, 9 test files / 60 tests, 4 skill tests). Dev page verified in Chromium.

Independent of #240 and of the other follow-ups — no file overlap.