### PR TITLE
* proj: replace the deprecated circle class with rounded-full

### DIFF
--- a/lib/alert/README.md
+++ b/lib/alert/README.md
@@ -95,7 +95,7 @@
 <div class="alert warning rounded-md">注意！看起来遇到一些问题。</div>
 <div class="alert danger rounded-lg">确实遇到了问题，请立即处理吧。</div>
 <div class="alert light rounded-xl">你可能需要了解一些内容。</div>
-<div class="alert important circle">欢迎使用ZUI3。</div>
+<div class="alert important rounded-full">欢迎使用ZUI3。</div>
 
 ```
 

--- a/lib/avatar-group/README.md
+++ b/lib/avatar-group/README.md
@@ -3,29 +3,29 @@
 ## Avatar-group
 ```html:example: -flex -gap-3 -items-end
 <div class="avatar-group size-xs">
-  <div class="avatar size-xs circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar size-xs circle success">Icon</div>
-  <div class="avatar size-xs circle warning">+1</div>
+  <div class="avatar size-xs rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar size-xs rounded-full success">Icon</div>
+  <div class="avatar size-xs rounded-full warning">+1</div>
 </div>
 <div class="avatar-group size-sm">
-  <div class="avatar size-sm circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar size-sm circle success">Icon</div>
-  <div class="avatar size-sm circle warning">+1</div>
+  <div class="avatar size-sm rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar size-sm rounded-full success">Icon</div>
+  <div class="avatar size-sm rounded-full warning">+1</div>
 </div>
 <div class="avatar-group ">
-  <div class="avatar circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar circle success">Icon</div>
-  <div class="avatar circle warning">+1</div>
+  <div class="avatar rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar rounded-full success">Icon</div>
+  <div class="avatar rounded-full warning">+1</div>
 </div>
 <div class="avatar-group size-lg">
-  <div class="avatar size-lg circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar size-lg circle success">Icon</div>
-  <div class="avatar size-lg circle warning">+1</div>
+  <div class="avatar size-lg rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar size-lg rounded-full success">Icon</div>
+  <div class="avatar size-lg rounded-full warning">+1</div>
 </div>
 <div class="avatar-group size-xl">
-  <div class="avatar size-xl circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar size-xl circle success">Icon</div>
-  <div class="avatar size-xl circle warning">+1</div>
+  <div class="avatar size-xl rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar size-xl rounded-full success">Icon</div>
+  <div class="avatar size-xl rounded-full warning">+1</div>
 </div>
 ```
 
@@ -73,9 +73,9 @@
   <div class="avatar warning rounded-xl">Z</div>
 </div>
 <div class="avatar-group">
-  <div class="avatar circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar success circle">头像</div>
-  <div class="avatar warning circle">Z</div>
+  <div class="avatar rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar success rounded-full">头像</div>
+  <div class="avatar warning rounded-full">Z</div>
 </div>
 ```
 
@@ -85,24 +85,24 @@ The default stack spacing equals `gap-2.5`. A smaller `gap-*` overlaps more, a l
 
 ```html:example: -flex -gap-3 -items-end
 <div class="avatar-group gap-0">
-  <div class="avatar circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar circle success">Icon</div>
-  <div class="avatar circle warning">0</div>
+  <div class="avatar rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar rounded-full success">Icon</div>
+  <div class="avatar rounded-full warning">0</div>
 </div>
 <div class="avatar-group gap-1">
-  <div class="avatar circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar circle success">Icon</div>
-  <div class="avatar circle warning">1</div>
+  <div class="avatar rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar rounded-full success">Icon</div>
+  <div class="avatar rounded-full warning">1</div>
 </div>
 <div class="avatar-group">
-  <div class="avatar circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar circle success">Icon</div>
-  <div class="avatar circle warning">2.5</div>
+  <div class="avatar rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar rounded-full success">Icon</div>
+  <div class="avatar rounded-full warning">2.5</div>
 </div>
 <div class="avatar-group gap-3.5">
-  <div class="avatar circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar circle success">Icon</div>
-  <div class="avatar circle warning">3.5</div>
+  <div class="avatar rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar rounded-full success">Icon</div>
+  <div class="avatar rounded-full warning">3.5</div>
 </div>
 ```
 
@@ -114,18 +114,18 @@ background other than the page canvas.
 
 ```html:example: -flex -gap-3 -items-end -bg-primary-500 -p-3
 <div class="avatar-group">
-  <div class="avatar circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar circle success">Icon</div>
-  <div class="avatar circle warning">+1</div>
+  <div class="avatar rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar rounded-full success">Icon</div>
+  <div class="avatar rounded-full warning">+1</div>
 </div>
 <div class="avatar-group" style="--avatar-group-ring-color: var(--color-primary-500);">
-  <div class="avatar circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar circle success">Icon</div>
-  <div class="avatar circle warning">+1</div>
+  <div class="avatar rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar rounded-full success">Icon</div>
+  <div class="avatar rounded-full warning">+1</div>
 </div>
 <div class="avatar-group" style="--avatar-group-ring-color: var(--color-warning-500); --avatar-group-ring-width: 3px;">
-  <div class="avatar circle"><img src="/lib/avatar/assets/avatar.png"></div>
-  <div class="avatar circle success">Icon</div>
-  <div class="avatar circle warning">+1</div>
+  <div class="avatar rounded-full"><img src="/lib/avatar/assets/avatar.png"></div>
+  <div class="avatar rounded-full success">Icon</div>
+  <div class="avatar rounded-full warning">+1</div>
 </div>
 ```

--- a/lib/avatar-group/docs/lib/components/index.md
+++ b/lib/avatar-group/docs/lib/components/index.md
@@ -12,12 +12,12 @@
 
 <Example class="flex gap-4 flex-wrap items-end">
   <div class="avatar-group">
-    <div class="avatar circle"><img src="/assets/avatar/avatar.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-1.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-2.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-3.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-4.png"></div>
-    <div class="avatar circle gray-200">+10</div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-2.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+    <div class="avatar rounded-full gray-200">+10</div>
   </div>
 </Example>
 
@@ -25,12 +25,12 @@
 
 ```html
 <div class="avatar-group">
-  <div class="avatar circle"><img src="/assets/avatar/avatar.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-1.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-2.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-3.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-4.png"></div>
-  <div class="avatar circle gray-200">+10</div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-2.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+  <div class="avatar rounded-full gray-200">+10</div>
 </div>
 ```
 
@@ -47,29 +47,29 @@
 
 <Example class="flex gap-4 flex-wrap items-end">
   <div class="avatar-group size-xs">
-    <div class="avatar size-xs circle"><img src="/assets/avatar/avatar-1.png"></div>
-    <div class="avatar size-xs circle"><img src="/assets/avatar/avatar-2.png"></div>
-    <div class="avatar size-xs circle"><img src="/assets/avatar/avatar-3.png"></div>
+    <div class="avatar size-xs rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+    <div class="avatar size-xs rounded-full"><img src="/assets/avatar/avatar-2.png"></div>
+    <div class="avatar size-xs rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
   </div>
   <div class="avatar-group size-sm">
-    <div class="avatar size-sm circle"><img src="/assets/avatar/avatar-4.png"></div>
-    <div class="avatar size-sm circle"><img src="/assets/avatar/avatar-5.png"></div>
-    <div class="avatar size-sm circle"><img src="/assets/avatar/avatar-6.png"></div>
+    <div class="avatar size-sm rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+    <div class="avatar size-sm rounded-full"><img src="/assets/avatar/avatar-5.png"></div>
+    <div class="avatar size-sm rounded-full"><img src="/assets/avatar/avatar-6.png"></div>
   </div>
   <div class="avatar-group">
-    <div class="avatar circle"><img src="/assets/avatar/avatar-7.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-8.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-9.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-7.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-8.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-9.png"></div>
   </div>
   <div class="avatar-group size-lg">
-    <div class="avatar size-lg circle"><img src="/assets/avatar/avatar-10.png"></div>
-    <div class="avatar size-lg circle"><img src="/assets/avatar/avatar-1.png"></div>
-    <div class="avatar size-lg circle"><img src="/assets/avatar/avatar-2.png"></div>
+    <div class="avatar size-lg rounded-full"><img src="/assets/avatar/avatar-10.png"></div>
+    <div class="avatar size-lg rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+    <div class="avatar size-lg rounded-full"><img src="/assets/avatar/avatar-2.png"></div>
   </div>
   <div class="avatar-group size-xl">
-    <div class="avatar size-xl circle"><img src="/assets/avatar/avatar-3.png"></div>
-    <div class="avatar size-xl circle"><img src="/assets/avatar/avatar-4.png"></div>
-    <div class="avatar size-xl circle"><img src="/assets/avatar/avatar-5.png"></div>
+    <div class="avatar size-xl rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
+    <div class="avatar size-xl rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+    <div class="avatar size-xl rounded-full"><img src="/assets/avatar/avatar-5.png"></div>
   </div>
 </Example>
 
@@ -77,29 +77,29 @@
 
 ```html
 <div class="avatar-group size-xs">
-  <div class="avatar size-xs circle"><img src="/assets/avatar/avatar-1.png"></div>
-  <div class="avatar size-xs circle"><img src="/assets/avatar/avatar-2.png"></div>
-  <div class="avatar size-xs circle"><img src="/assets/avatar/avatar-3.png"></div>
+  <div class="avatar size-xs rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+  <div class="avatar size-xs rounded-full"><img src="/assets/avatar/avatar-2.png"></div>
+  <div class="avatar size-xs rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
 </div>
 <div class="avatar-group size-sm">
-  <div class="avatar size-sm circle"><img src="/assets/avatar/avatar-4.png"></div>
-  <div class="avatar size-sm circle"><img src="/assets/avatar/avatar-5.png"></div>
-  <div class="avatar size-sm circle"><img src="/assets/avatar/avatar-6.png"></div>
+  <div class="avatar size-sm rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+  <div class="avatar size-sm rounded-full"><img src="/assets/avatar/avatar-5.png"></div>
+  <div class="avatar size-sm rounded-full"><img src="/assets/avatar/avatar-6.png"></div>
 </div>
 <div class="avatar-group">
-  <div class="avatar circle"><img src="/assets/avatar/avatar-7.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-8.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-9.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-7.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-8.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-9.png"></div>
 </div>
 <div class="avatar-group size-lg">
-  <div class="avatar size-lg circle"><img src="/assets/avatar/avatar-10.png"></div>
-  <div class="avatar size-lg circle"><img src="/assets/avatar/avatar-1.png"></div>
-  <div class="avatar size-lg circle"><img src="/assets/avatar/avatar-2.png"></div>
+  <div class="avatar size-lg rounded-full"><img src="/assets/avatar/avatar-10.png"></div>
+  <div class="avatar size-lg rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+  <div class="avatar size-lg rounded-full"><img src="/assets/avatar/avatar-2.png"></div>
 </div>
 <div class="avatar-group size-xl">
-  <div class="avatar size-xl circle"><img src="/assets/avatar/avatar-3.png"></div>
-  <div class="avatar size-xl circle"><img src="/assets/avatar/avatar-4.png"></div>
-  <div class="avatar size-xl circle"><img src="/assets/avatar/avatar-5.png"></div>
+  <div class="avatar size-xl rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
+  <div class="avatar size-xl rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+  <div class="avatar size-xl rounded-full"><img src="/assets/avatar/avatar-5.png"></div>
 </div>
 ```
 
@@ -116,34 +116,34 @@
 
 <Example class="flex gap-4 flex-wrap items-end">
   <div class="avatar-group gap-0">
-    <div class="avatar circle"><img src="/assets/avatar/avatar-1.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-2.png"></div>
-    <div class="avatar circle gray-200">0</div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-2.png"></div>
+    <div class="avatar rounded-full gray-200">0</div>
   </div>
   <div class="avatar-group gap-1">
-    <div class="avatar circle"><img src="/assets/avatar/avatar-4.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-5.png"></div>
-    <div class="avatar circle gray-200">1</div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-5.png"></div>
+    <div class="avatar rounded-full gray-200">1</div>
   </div>
   <div class="avatar-group gap-2">
-    <div class="avatar circle"><img src="/assets/avatar/avatar-7.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-8.png"></div>
-    <div class="avatar circle gray-200">2</div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-7.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-8.png"></div>
+    <div class="avatar rounded-full gray-200">2</div>
   </div>
   <div class="avatar-group">
-    <div class="avatar circle"><img src="/assets/avatar/avatar-10.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-1.png"></div>
-    <div class="avatar circle gray-200">2.5</div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-10.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+    <div class="avatar rounded-full gray-200">2.5</div>
   </div>
   <div class="avatar-group gap-3">
-    <div class="avatar circle"><img src="/assets/avatar/avatar-3.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-4.png"></div>
-    <div class="avatar circle gray-200">3</div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+    <div class="avatar rounded-full gray-200">3</div>
   </div>
   <div class="avatar-group gap-3.5">
-    <div class="avatar circle"><img src="/assets/avatar/avatar-6.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-7.png"></div>
-    <div class="avatar circle gray-200">3.5</div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-6.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-7.png"></div>
+    <div class="avatar rounded-full gray-200">3.5</div>
   </div>
 </Example>
 
@@ -151,34 +151,34 @@
 
 ```html
 <div class="avatar-group gap-0">
-  <div class="avatar circle"><img src="/assets/avatar/avatar-1.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-2.png"></div>
-  <div class="avatar circle gray-200">0</div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-2.png"></div>
+  <div class="avatar rounded-full gray-200">0</div>
 </div>
 <div class="avatar-group gap-1">
-  <div class="avatar circle"><img src="/assets/avatar/avatar-4.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-5.png"></div>
-  <div class="avatar circle gray-200">1</div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-5.png"></div>
+  <div class="avatar rounded-full gray-200">1</div>
 </div>
 <div class="avatar-group gap-2">
-  <div class="avatar circle"><img src="/assets/avatar/avatar-7.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-8.png"></div>
-  <div class="avatar circle gray-200">2</div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-7.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-8.png"></div>
+  <div class="avatar rounded-full gray-200">2</div>
 </div>
 <div class="avatar-group">
-  <div class="avatar circle"><img src="/assets/avatar/avatar-10.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-1.png"></div>
-  <div class="avatar circle gray-200">2.5</div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-10.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+  <div class="avatar rounded-full gray-200">2.5</div>
 </div>
 <div class="avatar-group gap-3">
-  <div class="avatar circle"><img src="/assets/avatar/avatar-3.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-4.png"></div>
-  <div class="avatar circle gray-200">3</div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+  <div class="avatar rounded-full gray-200">3</div>
 </div>
 <div class="avatar-group gap-3.5">
-  <div class="avatar circle"><img src="/assets/avatar/avatar-6.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-7.png"></div>
-  <div class="avatar circle gray-200">3.5</div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-6.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-7.png"></div>
+  <div class="avatar rounded-full gray-200">3.5</div>
 </div>
 ```
 
@@ -213,14 +213,14 @@
 
 <Example class="flex gap-4 flex-wrap items-end bg-primary-500 p-3">
   <div class="avatar-group">
-    <div class="avatar circle"><img src="/assets/avatar/avatar-1.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-2.png"></div>
-    <div class="avatar circle gray-200">+10</div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-1.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-2.png"></div>
+    <div class="avatar rounded-full gray-200">+10</div>
   </div>
   <div class="avatar-group" style="--avatar-group-ring-color: var(--color-primary-500);">
-    <div class="avatar circle"><img src="/assets/avatar/avatar-3.png"></div>
-    <div class="avatar circle"><img src="/assets/avatar/avatar-4.png"></div>
-    <div class="avatar circle gray-200">+10</div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
+    <div class="avatar rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+    <div class="avatar rounded-full gray-200">+10</div>
   </div>
 </Example>
 
@@ -228,9 +228,9 @@
 
 ```html
 <div class="avatar-group" style="--avatar-group-ring-color: var(--color-primary-500);">
-  <div class="avatar circle"><img src="/assets/avatar/avatar-3.png"></div>
-  <div class="avatar circle"><img src="/assets/avatar/avatar-4.png"></div>
-  <div class="avatar circle gray-200">+10</div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-3.png"></div>
+  <div class="avatar rounded-full"><img src="/assets/avatar/avatar-4.png"></div>
+  <div class="avatar rounded-full gray-200">+10</div>
 </div>
 ```
 

--- a/lib/avatar/README.md
+++ b/lib/avatar/README.md
@@ -46,27 +46,27 @@ new Avatar('#avatar6', {
 ## Rounded
 
 ```html:example: -flex -gap-3
-<div class="avatar circle"><img src="@/assets/avatar.png"></div>
+<div class="avatar rounded-full"><img src="@/assets/avatar.png"></div>
 ```
 
 ## Outline
 
 ```html:example: -flex -gap-3
-<div class="avatar circle primary-outline">孙</div>
-<div class="avatar circle secondary-outline">李</div>
-<div class="avatar circle success-outline">周</div>
-<div class="avatar circle danger-outline">吴</div>
-<div class="avatar circle important-outline">郑</div>
-<div class="avatar circle special-outline">王</div>
+<div class="avatar rounded-full primary-outline">孙</div>
+<div class="avatar rounded-full secondary-outline">李</div>
+<div class="avatar rounded-full success-outline">周</div>
+<div class="avatar rounded-full danger-outline">吴</div>
+<div class="avatar rounded-full important-outline">郑</div>
+<div class="avatar rounded-full special-outline">王</div>
 ```
 
 ## Icon/Text Avatar
 
 ```html:example: -flex -gap-3 -items-end
 <div class="avatar primary">Icon</div>
-<div class="avatar circle primary">Icon</div>
+<div class="avatar rounded-full primary">Icon</div>
 <div class="avatar primary"><span>王</span></div>
-<div class="avatar circle primary"><span>王</span></div>
+<div class="avatar rounded-full primary"><span>王</span></div>
 ```
 
 ## Sizes
@@ -106,7 +106,7 @@ new Avatar('#avatar6', {
 <div class="avatar rounded"><img src="@/assets/avatar-8.png"></div>
 <div class="avatar rounded-lg"><img src="@/assets/avatar-9.png"></div>
 <div class="avatar rounded-xl"><img src="@/assets/avatar-10.png"></div>
-<div class="avatar circle"><img src="@/assets/avatar.png"></div>
+<div class="avatar rounded-full"><img src="@/assets/avatar.png"></div>
 ```
 
 ## 其他说明

--- a/lib/avatar/src/component/avatar.tsx
+++ b/lib/avatar/src/component/avatar.tsx
@@ -55,7 +55,9 @@ export class Avatar extends Component<AvatarOptions> {
             }
         }
         if (circle) {
-            finalClass.push('rounded-full');
+            // `circle` is deprecated in favour of `rounded-full` (utilities/borders/rounded.css).
+            // Both are emitted until the alias itself is dropped, so consumer CSS still matches.
+            finalClass.push('rounded-full', 'circle');
         } else if (rounded) {
             if (typeof rounded === 'number') {
                 finalStyle.borderRadius = `${rounded}px`;

--- a/lib/avatar/src/component/avatar.tsx
+++ b/lib/avatar/src/component/avatar.tsx
@@ -55,7 +55,7 @@ export class Avatar extends Component<AvatarOptions> {
             }
         }
         if (circle) {
-            finalClass.push('circle');
+            finalClass.push('rounded-full');
         } else if (rounded) {
             if (typeof rounded === 'number') {
                 finalStyle.borderRadius = `${rounded}px`;

--- a/lib/button/README.md
+++ b/lib/button/README.md
@@ -141,7 +141,7 @@
 <button type="button" class="rounded-md btn primary">Button</button>
 <button type="button" class="rounded-lg btn primary">Button</button>
 <button type="button" class="btn primary rounded-xl">Button</button>
-<button type="button" class="btn primary circle">Button</button>
+<button type="button" class="btn primary rounded-full">Button</button>
 ```
 
 ## Shadow

--- a/lib/button/docs/lib/components/index.md
+++ b/lib/button/docs/lib/components/index.md
@@ -32,8 +32,8 @@
   <button type="button" class="btn primary">主要按钮</button>
   <button type="button" class="btn black rounded-none">黑色按钮</button>
   <button type="button" class="btn secondary-outline square">正</button>
-  <button type="button" class="btn dark-outline circle">描边</button>
-  <button type="button" class="btn danger-pale square circle">❤️</button>
+  <button type="button" class="btn dark-outline rounded-full">描边</button>
+  <button type="button" class="btn danger-pale square rounded-full">❤️</button>
   <button type="button" class="btn text-primary ghost">链接按钮</button>
 </Example>
 
@@ -43,8 +43,8 @@
 <button type="button" class="btn primary">主要按钮</button>
 <button type="button" class="btn black rounded-none">黑色按钮</button>
 <button type="button" class="btn secondary-outline square">正</button>
-<button type="button" class="btn dark-outline circle">描边</button>
-<button type="button" class="btn danger-pale square circle">❤️</button>
+<button type="button" class="btn dark-outline rounded-full">描边</button>
+<button type="button" class="btn danger-pale square rounded-full">❤️</button>
 <button type="button" class="btn text-primary ghost">链接按钮</button>
 ```
 
@@ -268,28 +268,28 @@
 
 ### 圆形按钮
 
-当与工具类 `circle` 与 `square` 一起使用时则获得圆形按钮。
+当与工具类 `rounded-full` 与 `square` 一起使用时则获得圆形按钮。
 
 ::: tabs
 
 == 示例
 
 <Example class="flex gap-4 items-end">
-  <button type="button" class="btn square circle size-xs">XS</button>
-  <button type="button" class="btn square circle size-sm">S</button>
-  <button type="button" class="btn square circle">正</button>
-  <button type="button" class="btn square circle size-lg">L</button>
-  <button type="button" class="btn square circle size-xl">XL</button>
+  <button type="button" class="btn square rounded-full size-xs">XS</button>
+  <button type="button" class="btn square rounded-full size-sm">S</button>
+  <button type="button" class="btn square rounded-full">正</button>
+  <button type="button" class="btn square rounded-full size-lg">L</button>
+  <button type="button" class="btn square rounded-full size-xl">XL</button>
 </Example>
 
 == HTML
 
 ```html
-<button type="button" class="btn square circle size-xs">XS</button>
-<button type="button" class="btn square circle size-sm">S</button>
-<button type="button" class="btn square circle">正</button>
-<button type="button" class="btn square circle size-lg">L</button>
-<button type="button" class="btn square circle size-xl">XL</button>
+<button type="button" class="btn square rounded-full size-xs">XS</button>
+<button type="button" class="btn square rounded-full size-sm">S</button>
+<button type="button" class="btn square rounded-full">正</button>
+<button type="button" class="btn square rounded-full size-lg">L</button>
+<button type="button" class="btn square rounded-full size-xl">XL</button>
 ```
 
 :::

--- a/lib/core/docs/lib/basic/css-component.md
+++ b/lib/core/docs/lib/basic/css-component.md
@@ -42,8 +42,8 @@ CSS 组件通常提供了多种样式修饰，例如按钮的颜色、大小、�
   <button type="button" class="btn primary">主要按钮</button>
   <button type="button" class="btn black rounded-none">黑色按钮</button>
   <button type="button" class="btn secondary-outline square">正</button>
-  <button type="button" class="btn dark-outline circle">描边</button>
-  <button type="button" class="btn danger-pale square circle">❤️</button>
+  <button type="button" class="btn dark-outline rounded-full">描边</button>
+  <button type="button" class="btn danger-pale square rounded-full">❤️</button>
   <button type="button" class="btn text-primary ghost">链接按钮</button>
 </Example>
 
@@ -53,8 +53,8 @@ CSS 组件通常提供了多种样式修饰，例如按钮的颜色、大小、�
 <button type="button" class="btn primary">主要按钮</button>
 <button type="button" class="btn black rounded-none">黑色按钮</button>
 <button type="button" class="btn secondary-outline square">正</button>
-<button type="button" class="btn dark-outline circle">描边</button>
-<button type="button" class="btn danger-pale square circle">❤️</button>
+<button type="button" class="btn dark-outline rounded-full">描边</button>
+<button type="button" class="btn danger-pale square rounded-full">❤️</button>
 <button type="button" class="btn text-primary ghost">链接按钮</button>
 ```
 

--- a/lib/dtable/dev.ts
+++ b/lib/dtable/dev.ts
@@ -178,7 +178,7 @@ onPageUpdate(() => {
                 };
                 if (releaseIncrease > 6) {
                     result.push({
-                        html: `<span class="label size-sm ${row.data?.milestone ? 'important' : 'secondary'}-pale circle">+${releaseIncrease - 6}</span>`,
+                        html: `<span class="label size-sm ${row.data?.milestone ? 'important' : 'secondary'}-pale rounded-full">+${releaseIncrease - 6}</span>`,
                     });
                 }
                 result.push({attrs: {'data-toggle': 'popover', 'data-content': '发布说明'}});

--- a/lib/input-control/docs/lib/forms/index.md
+++ b/lib/input-control/docs/lib/forms/index.md
@@ -270,7 +270,7 @@
 
 <Example class="flex gap-4 flex-wrap items-end">
   <div class="input-control">
-    <input type="text" class="form-control circle" placeholder="请填写" />
+    <input type="text" class="form-control rounded-full" placeholder="请填写" />
   </div>
   <div class="input-control">
     <input type="text" class="form-control shadow" placeholder="请填写" />
@@ -279,7 +279,7 @@
 
 ```html
 <div class="input-control">
-  <input type="text" class="form-control circle" placeholder="请填写" />
+  <input type="text" class="form-control rounded-full" placeholder="请填写" />
 </div>
 <div class="input-control">
   <input type="text" class="form-control shadow" placeholder="请填写" />

--- a/lib/menu/README.md
+++ b/lib/menu/README.md
@@ -154,7 +154,7 @@ console.log('> menu', menu);
 ```html:example
 <menu class="menu -w-36">
   <li class="row items-center gap-2 py-1 px-2">
-    <div class="avatar circle flex-none"><img src="/lib/avatar/assets/avatar.png"></div>
+    <div class="avatar rounded-full flex-none"><img src="/lib/avatar/assets/avatar.png"></div>
     <div class="flex-auto">
       <div>张三</div>
       <div class="text-gray text-sm">zhangsan</div>

--- a/lib/menu/docs/lib/components/index.md
+++ b/lib/menu/docs/lib/components/index.md
@@ -243,7 +243,7 @@
 <Example>
   <menu class="menu -w-36">
     <li class="row items-center gap-2 py-1 px-2">
-      <div class="avatar circle flex-none"><img src="/assets/avatar/avatar.png"></div>
+      <div class="avatar rounded-full flex-none"><img src="/assets/avatar/avatar.png"></div>
       <div class="flex-auto">
         <div>张三</div>
         <div class="text-gray text-sm">zhangsan</div>
@@ -263,7 +263,7 @@
 ```html
 <menu class="menu -w-36">
   <li class="row items-center gap-2 py-1 px-2">
-    <div class="avatar circle flex-none"><img src="/assets/avatar/avatar.png"></div>
+    <div class="avatar rounded-full flex-none"><img src="/assets/avatar/avatar.png"></div>
     <div class="flex-auto">
       <div>张三</div>
       <div class="text-gray text-sm">zhangsan</div>

--- a/lib/messager/README.md
+++ b/lib/messager/README.md
@@ -106,21 +106,21 @@ document.querySelector('.messager-toggle').addEventListener('click', (event) => 
 <button type="button" class="btn messager-toggle danger" data-type="danger">danger</button>
 <button type="button" class="btn messager-toggle special" data-type="special">special</button>
 <button type="button" class="btn messager-toggle important" data-type="important">important</button>
-<button type="button" class="btn messager-toggle primary circle" data-type="primary circle">primary circle</button>
+<button type="button" class="btn messager-toggle primary rounded-full" data-type="primary rounded-full">primary rounded-full</button>
 <button type="button" class="btn messager-toggle primary-pale" data-type="primary-pale">primary-pale</button>
 <button type="button" class="btn messager-toggle secondary-pale" data-type="secondary-pale">secondary-pale</button>
 <button type="button" class="btn messager-toggle success-pale" data-type="success-pale">success-pale</button>
 <button type="button" class="btn messager-toggle danger-pale" data-type="danger-pale">danger-pale</button>
 <button type="button" class="btn messager-toggle special-pale" data-type="special-pale">special-pale</button>
 <button type="button" class="btn messager-toggle important-pale" data-type="important-pale">important-pale</button>
-<button type="button" class="btn messager-toggle primary-pale circle" data-type="primary-pale circle">primary-pale circle</button>
+<button type="button" class="btn messager-toggle primary-pale rounded-full" data-type="primary-pale rounded-full">primary-pale rounded-full</button>
 <button type="button" class="btn messager-toggle primary-outline" data-type="primary-outline">primary-outline</button>
 <button type="button" class="btn messager-toggle secondary-outline" data-type="secondary-outline">secondary-outline</button>
 <button type="button" class="btn messager-toggle success-outline" data-type="success-outline">success-outline</button>
 <button type="button" class="btn messager-toggle danger-outline" data-type="danger-outline">danger-outline</button>
 <button type="button" class="btn messager-toggle special-outline" data-type="special-outline">special-outline</button>
 <button type="button" class="btn messager-toggle important-outline" data-type="important-outline">important-outline</button>
-<button type="button" class="btn messager-toggle primary-outline circle" data-type="primary-outline circle">primary-outline circle</button>
+<button type="button" class="btn messager-toggle primary-outline rounded-full" data-type="primary-outline rounded-full">primary-outline rounded-full</button>
 ```
 
 ```js

--- a/lib/messager/docs/lib/components/index.md
+++ b/lib/messager/docs/lib/components/index.md
@@ -74,9 +74,9 @@ Messager.show({
   <button type="button" class="btn important" data-on="click" data-do="zui.Messager.show({content: '嘿！这是一条消息。', type: 'important'});">important</button>
   <button type="button" class="btn gray" data-on="click" data-do="zui.Messager.show({content: '嘿！这是一条消息。', type: 'gray'});">gray</button>
   <button type="button" class="btn black" data-on="click" data-do="zui.Messager.show({content: '嘿！这是一条消息。', type: 'black'});">black</button>
-  <button type="button" class="btn primary circle" data-on="click" data-do="zui.Messager.show({content: '嘿！这是一条消息。', type: 'primary circle'});">primary circle</button>
-  <button type="button" class="btn success-pale circle" data-on="click" data-do="zui.Messager.show({content: '嘿！这是一条消息。', type: 'success-pale circle'});">success-pale circle</button>
-  <button type="button" class="btn danger-outline circle" data-on="click" data-do="zui.Messager.show({content: '嘿！这是一条消息。', type: 'danger-outline circle'});">danger-outline circle</button>
+  <button type="button" class="btn primary rounded-full" data-on="click" data-do="zui.Messager.show({content: '嘿！这是一条消息。', type: 'primary rounded-full'});">primary rounded-full</button>
+  <button type="button" class="btn success-pale rounded-full" data-on="click" data-do="zui.Messager.show({content: '嘿！这是一条消息。', type: 'success-pale rounded-full'});">success-pale rounded-full</button>
+  <button type="button" class="btn danger-outline rounded-full" data-on="click" data-do="zui.Messager.show({content: '嘿！这是一条消息。', type: 'danger-outline rounded-full'});">danger-outline rounded-full</button>
 </example>
 
 == JS

--- a/lib/pager/README.md
+++ b/lib/pager/README.md
@@ -205,12 +205,12 @@ new Pager('#pagerGoto', {
   <button type="button" class="btn"><i class="icon icon-angle-right"></i></button>
 </div>
 <div class="pager pager-loose gap-x-3">
-  <button type="button" class="btn circle"><i class="icon icon-angle-left"></i></button>
-  <button type="button" class="btn circle">1</button>
-  <button type="button" class="btn circle active primary">2</button>
-  <button type="button" class="btn circle">3</button>
-  <button type="button" class="btn circle">4</button>
-  <button type="button" class="btn circle"><i class="icon icon-angle-right"></i></button>
+  <button type="button" class="btn rounded-full"><i class="icon icon-angle-left"></i></button>
+  <button type="button" class="btn rounded-full">1</button>
+  <button type="button" class="btn rounded-full active primary">2</button>
+  <button type="button" class="btn rounded-full">3</button>
+  <button type="button" class="btn rounded-full">4</button>
+  <button type="button" class="btn rounded-full"><i class="icon icon-angle-right"></i></button>
 </div>
 ```
 

--- a/lib/progress/README.md
+++ b/lib/progress/README.md
@@ -88,7 +88,7 @@ new ProgressBar('#progressBarExample', {percent: 65, height: 20, width: 320});
   </div>
 ```
 ```html:example
-  <div class="progress mb-5 circle">
+  <div class="progress mb-5 rounded-full">
     <div class="progress-bar " style="width: 40%">
     </div>
   </div>

--- a/lib/upload-imgs/src/vanilla/upload-imgs.ts
+++ b/lib/upload-imgs/src/vanilla/upload-imgs.ts
@@ -119,7 +119,7 @@ export class UploadImgs extends Upload<UploadImgsOptions> {
         if (showSize) {
             $fileItem.append(
                 this.fileSize(file.size)
-                    .addClass('file-size label text-white circle darker absolute px-1 hidden')
+                    .addClass('file-size label text-white rounded-full darker absolute px-1 hidden')
                     .removeClass('text-gray')
                     .css({top: 96, left: 4}),
             );

--- a/lib/upload-imgs/src/vanilla/upload-imgs.ts
+++ b/lib/upload-imgs/src/vanilla/upload-imgs.ts
@@ -119,7 +119,7 @@ export class UploadImgs extends Upload<UploadImgsOptions> {
         if (showSize) {
             $fileItem.append(
                 this.fileSize(file.size)
-                    .addClass('file-size label text-white rounded-full darker absolute px-1 hidden')
+                    .addClass('file-size label text-white rounded-full circle darker absolute px-1 hidden')
                     .removeClass('text-gray')
                     .css({top: 96, left: 4}),
             );

--- a/lib/utilities/docs/utilities/effects/animation.md
+++ b/lib/utilities/docs/utilities/effects/animation.md
@@ -38,7 +38,7 @@
 
 <Example>
   <div class="animate-pulse rounded w-full max-auto flex px-4 py-4">
-    <div class="w-16 h-16 bg-primary circle">
+    <div class="w-16 h-16 bg-primary rounded-full">
     </div>
     <div class="flex-1 h-16 px-4 ">
       <div class="h-4 w-48 bg-primary mb-2 rounded"></div>
@@ -50,7 +50,7 @@
 
 ```html
 <div class="animate-pulse rounded w-full max-auto flex px-4 py-4">
-  <div class="w-16 h-16 bg-primary circle">
+  <div class="w-16 h-16 bg-primary rounded-full">
   </div>
   <div class="flex-1 h-16 px-4 ">
     <div class="h-4 w-48 bg-primary mb-2 rounded"></div>

--- a/tests/dom/avatar.test.tsx
+++ b/tests/dom/avatar.test.tsx
@@ -39,7 +39,7 @@ describe('Avatar', () => {
         expect(avatar.style.width).toBe('20px');
         expect(avatar.style.height).toBe('20px');
         expect(avatar.style.fontSize).toBe('12px');
-        expect(avatar).toHaveClass('circle');
+        expect(avatar).toHaveClass('rounded-full');
         expect(avatar).not.toHaveClass('rounded-lg');
         expect(text.style.transform).toBe('scale(0.625)');
         expect(text.dataset.actualsize).toBe('20');
@@ -78,7 +78,7 @@ describe('Avatar', () => {
         await flushAnimationFrame();
 
         expect(within(host).getByText('U')).toBeInTheDocument();
-        expect(host.querySelector('.avatar')).toHaveClass('circle');
+        expect(host.querySelector('.avatar')).toHaveClass('rounded-full');
 
         avatar.render({displayText: 'ZU', text: undefined});
         expect(within(host).getByText('ZU')).toBeInTheDocument();

--- a/tests/dom/avatar.test.tsx
+++ b/tests/dom/avatar.test.tsx
@@ -39,7 +39,7 @@ describe('Avatar', () => {
         expect(avatar.style.width).toBe('20px');
         expect(avatar.style.height).toBe('20px');
         expect(avatar.style.fontSize).toBe('12px');
-        expect(avatar).toHaveClass('rounded-full');
+        expect(avatar).toHaveClass('rounded-full', 'circle');
         expect(avatar).not.toHaveClass('rounded-lg');
         expect(text.style.transform).toBe('scale(0.625)');
         expect(text.dataset.actualsize).toBe('20');
@@ -78,7 +78,7 @@ describe('Avatar', () => {
         await flushAnimationFrame();
 
         expect(within(host).getByText('U')).toBeInTheDocument();
-        expect(host.querySelector('.avatar')).toHaveClass('rounded-full');
+        expect(host.querySelector('.avatar')).toHaveClass('rounded-full', 'circle');
 
         avatar.render({displayText: 'ZU', text: undefined});
         expect(within(host).getByText('ZU')).toBeInTheDocument();


### PR DESCRIPTION
`lib/utilities/src/borders/rounded.css:9` marks `.circle` deprecated in favour of
`.rounded-full`, aliasing both to `-rounded-full`. This sweeps the remaining call sites.

**Stacked on #240.** 126 of the sites live in `lib/avatar-group/README.md` and its docs
page, both rewritten by that PR, so the base is `dev_optimize_css_libs` rather than
`dev_optimize`. When #240 merges GitHub retargets this automatically — *provided the
branch is deleted on merge*; otherwise retarget by hand.

## Commits

1. **docs and dev pages** — 190 replacements over 178 lines in 16 files.
2. **component output** — `@zui/avatar` and `@zui/upload-imgs` move to `rounded-full`.
3. **compatibility** — those two keep emitting `circle` as well.

Commits 2 and 3 are kept separate because the middle state is the interesting one to
review: 2 alone is a breaking change for downstream CSS, and 3 is the reason this PR is
not one. Happy to squash them if you prefer a single commit.

## No breaking change

Commit 2 on its own would break anyone whose CSS selects `.circle` on an avatar or on the
upload-imgs file-size badge — the only part of this branch with blast radius outside the
repo, hiding inside what otherwise reads as a docs sweep. Commit 3 emits **both** classes
instead, the ordinary way to retire a class in shipped output: existing consumer CSS keeps
matching, while the components stop making the deprecated name the only option.

The two DOM tests assert both names, so dropping either becomes a deliberate edit. When
the alias is finally removed from `rounded.css`, `circle` comes out of the two call sites
and the two assertions together.

`@zui/search-box` emits only `rounded-full` for its identical `circle` option
(`search-box.tsx:188`). That break already shipped; left alone rather than widening this PR.

## Two things the original scan missed

The sweep was scoped from a scan of `class` / `className` attribute values, which found
177 sites. Two categories sit outside that shape and are included here:

- **Runtime class strings in two components** — `avatar/src/component/avatar.tsx:58`
  (`finalClass.push('circle')`) and `upload-imgs/src/vanilla/upload-imgs.ts:122`
  (`.addClass('… circle …')`) put the class into consumers' DOM, not just the docs.
- **`data-type` / `type` values in the messager docs.** `messager-item.tsx:44` feeds
  `type` straight into `classes()`, so `data-type="primary circle"` renders the class at
  runtime. Their button labels mirror the value and move with it.

## Deliberately untouched

`light-circle`, `progress-circle`, the `.circle` selector in `rounded.css` itself, the
`<circle>` SVG elements in `@zui/progress-circle`, the `circleColor` / `circleWidth` /
`circleBg` props, and the `circle` option props of `@zui/avatar`, `@zui/picker` and
`@zui/search-box`. A loose `s/circle/rounded-full/g` corrupts all of these.

**Removing the deprecated alias from `rounded.css` is out of scope** — it is a public CSS
class and dropping it breaks downstream consumers. Sweep first, decide the alias later.

## Verification

- 0 remaining `circle` class tokens in docs under `lib/`; guard-token counts unchanged
  (`light-circle` 49, `progress-circle` 10, `circleColor` 12, `circleWidth` 13,
  `circleBg` 9, `circleSize` 5, `<circle` 2).
- Every changed doc line differs only by the token — checked line-by-line, not by eye.
- `pnpm build` emits **byte-identical CSS** for all seven artifacts.
- The rendered avatar-group docs page has all **584 class attributes identical** once
  `circle` and `rounded-full` are normalised to one token.
- `pnpm check` green; `pnpm docs:build` green.

## Note on line endings

Four `.md` files use CRLF (`avatar/README.md`, both `avatar-group` files,
`input-control/docs/…/index.md`). A first pass normalised them to LF and inflated the diff
to 838 lines; endings are preserved here, so the doc diff is 182 lines.
