### PR TITLE
+ proj: derive the zui keyword from lib type and guard it

### DIFF
--- a/lib/alert/package.json
+++ b/lib/alert/package.json
@@ -4,6 +4,7 @@
     "main": "src/main.ts",
     "browser": "src/main.ts",
     "browserslist": "",
+    "keywords": ["zui:control"],
     "files": [
         "./src/**/*"
     ],

--- a/lib/avatar-group/package.json
+++ b/lib/avatar-group/package.json
@@ -4,7 +4,7 @@
     "main": "src/main.ts",
     "browser": "src/main.ts",
     "browserslist": "",
-    "keywords": ["css", "zui:control"],
+    "keywords": ["css", "zui:component"],
     "dependencies": {
         "@zui/avatar": "workspace:0.0.1"
     },

--- a/lib/avatar/package.json
+++ b/lib/avatar/package.json
@@ -4,6 +4,7 @@
     "version": "0.0.1",
     "main": "src/main.ts",
     "browserslist": "",
+    "keywords": ["zui:component"],
     "dependencies": {
         "@zui/core": "workspace:*",
         "@zui/helpers": "workspace:*"

--- a/lib/breadcrumb/package.json
+++ b/lib/breadcrumb/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/breadcrumb",
     "description": "ZUI breadcrumb",
     "version": "0.0.1",
-    "keywords": ["css", "components"],
+    "keywords": ["css", "components", "zui:control"],
     "main": "src/main.ts",
     "devDependencies": {
         "@zui/base": "workspace:*",

--- a/lib/btn-group/package.json
+++ b/lib/btn-group/package.json
@@ -6,7 +6,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "files": [
         "./src/**/*"

--- a/lib/cards/package.json
+++ b/lib/cards/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "js",
         "cs",
-        "zui:component"
+        "zui:js-ui"
     ],
     "main": "src/main.ts",
     "module": "src/main.ts",

--- a/lib/checkbox/package.json
+++ b/lib/checkbox/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/checkbox",
     "description": "ZUI checkbox",
     "version": "0.0.1",
-    "keywords": ["css", "components"],
+    "keywords": ["css", "components", "zui:control"],
     "main": "src/main.ts",
     "exports": {
         ".": "./src/main.ts",

--- a/lib/collapsible/package.json
+++ b/lib/collapsible/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/collapsible",
     "description": "ZUI Collapsible",
     "version": "0.0.1",
-    "keywords": ["css", "components"],
+    "keywords": ["css", "components", "zui:control"],
     "main": "src/main.ts",
     "devDependencies": {
         "@zui/base": "workspace:*",

--- a/lib/color-picker/package.json
+++ b/lib/color-picker/package.json
@@ -5,7 +5,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "files": [
         "./src/**/*"

--- a/lib/common-list/package.json
+++ b/lib/common-list/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.1",
     "main": "src/main.ts",
     "browserslist": "",
+    "keywords": ["zui:control"],
     "files": [
         "./src/**/*"
     ],

--- a/lib/contextmenu/package.json
+++ b/lib/contextmenu/package.json
@@ -6,7 +6,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:js-ui"
     ],
     "files": [
         "./src/**/*"

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.1",
     "main": "src/main.ts",
     "browser": "src/main.ts",
+    "keywords": ["zui:js-helpers"],
     "files": [
         "./src/**/*"
     ],

--- a/lib/dashboard/package.json
+++ b/lib/dashboard/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "js",
         "cs",
-        "zui:component"
+        "zui:js-ui"
     ],
     "main": "src/main.ts",
     "module": "src/main.ts",

--- a/lib/datetime-picker/package.json
+++ b/lib/datetime-picker/package.json
@@ -5,7 +5,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "files": [
         "./src/**/*"

--- a/lib/dnd/package.json
+++ b/lib/dnd/package.json
@@ -4,7 +4,7 @@
     "version": "0.0.1",
     "keywords": [
         "js",
-        "zui:js-lib"
+        "zui:js-helpers"
     ],
     "browser": "src/main.ts",
     "main": "src/main.ts",

--- a/lib/dropdown/package.json
+++ b/lib/dropdown/package.json
@@ -6,7 +6,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:js-ui"
     ],
     "files": [
         "./src/**/*"

--- a/lib/dtable/package.json
+++ b/lib/dtable/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "js",
         "cs",
-        "zui:component"
+        "zui:js-ui"
     ],
     "main": "src/main.ts",
     "module": "src/main.ts",

--- a/lib/event-bus/package.json
+++ b/lib/event-bus/package.json
@@ -2,6 +2,7 @@
     "name": "@zui/event-bus",
     "description": "ZUI event bus for browser",
     "version": "0.0.1",
+    "keywords": ["zui:js-helpers"],
     "type": "module",
     "main": "src/main.ts",
     "module": "src/main.ts",

--- a/lib/file-selector/package.json
+++ b/lib/file-selector/package.json
@@ -10,7 +10,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "files": [
         "./src/**/*"

--- a/lib/form-builder/package.json
+++ b/lib/form-builder/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@zui/form-builder",
     "version": "0.0.1",
+    "keywords": ["zui:component"],
     "main": "src/main.ts",
     "exports": {
         ".": "./src/main.ts",

--- a/lib/form-control/package.json
+++ b/lib/form-control/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@zui/form-control",
     "version": "0.0.1",
+    "keywords": ["zui:control"],
     "main": "src/main.ts",
     "exports": {
         ".": "./src/main.ts",

--- a/lib/form-helper/package.json
+++ b/lib/form-helper/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@zui/form-helper",
     "version": "0.0.1",
+    "keywords": ["zui:js-helpers"],
     "main": "src/main.ts",
     "exports": {
         ".": "./src/main.ts"

--- a/lib/form/package.json
+++ b/lib/form/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@zui/form",
     "version": "0.0.1",
+    "keywords": ["zui:control"],
     "main": "src/main.ts",
     "dependencies": {
         "@zui/input-group": "workspace:*",

--- a/lib/helpers/package.json
+++ b/lib/helpers/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/helpers",
     "description": "ZUI helpers",
     "version": "0.0.1",
-    "keywords": ["js", "zui:js-helpers"],
+    "keywords": ["js", "zui:js-lib"],
     "main": "src/main.ts",
     "module": "src/main.ts",
     "files": [

--- a/lib/input-group/package.json
+++ b/lib/input-group/package.json
@@ -6,7 +6,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "dependencies": {
         "@zui/form-control": "workspace:*"

--- a/lib/kanban/package.json
+++ b/lib/kanban/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "js",
         "cs",
-        "zui:component"
+        "zui:js-ui"
     ],
     "main": "src/main.ts",
     "module": "src/main.ts",

--- a/lib/list/package.json
+++ b/lib/list/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.1",
     "main": "src/main.ts",
     "browser": "src/main.ts",
+    "keywords": ["zui:control"],
     "files": [
         "./src/**/*"
     ],

--- a/lib/modal/package.json
+++ b/lib/modal/package.json
@@ -4,7 +4,7 @@
     "main": "src/main.ts",
     "browser": "src/main.ts",
     "browserslist": "",
-    "keywords": ["css", "zui:control"],
+    "keywords": ["css", "zui:component"],
     "files": [
         "./src/**/*"
     ],

--- a/lib/nav/package.json
+++ b/lib/nav/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/nav",
     "description": "ZUI nav",
     "version": "0.0.1",
-    "keywords": ["css", "components"],
+    "keywords": ["css", "components", "zui:component"],
     "main": "src/main.ts",
     "devDependencies": {
         "@zui/avatar": "workspace:^0.0.1",

--- a/lib/pager/package.json
+++ b/lib/pager/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/pager",
     "description": "ZUI pager",
     "version": "0.0.1",
-    "keywords": ["css", "components"],
+    "keywords": ["css", "components", "zui:component"],
     "main": "src/main.ts",
     "dependencies": {
       "@zui/button": "workspace:^0.0.1",

--- a/lib/panel/package.json
+++ b/lib/panel/package.json
@@ -6,7 +6,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "devDependencies": {
         "@zui/base": "workspace:*",

--- a/lib/pick/package.json
+++ b/lib/pick/package.json
@@ -5,7 +5,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "files": [
         "./src/**/*"

--- a/lib/picker/package.json
+++ b/lib/picker/package.json
@@ -5,7 +5,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "files": [
         "./src/**/*"

--- a/lib/popover/package.json
+++ b/lib/popover/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/popover",
     "description": "ZUI Toolbar",
     "version": "0.0.1",
-    "keywords": ["css", "components"],
+    "keywords": ["css", "components", "zui:component"],
     "main": "src/main.ts",
     "devDependencies": {
         "zui-dev": "workspace:^0.0.1"

--- a/lib/progress-circle/package.json
+++ b/lib/progress-circle/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/progress-circle",
     "description": "ZUI progress-circle",
     "version": "0.0.1",
-    "keywords": ["js", "zui:js-progress-circle"],
+    "keywords": ["js", "zui:control"],
     "module": "src/main.ts",
     "files": [
         "./src/**/*"

--- a/lib/progress/package.json
+++ b/lib/progress/package.json
@@ -3,7 +3,7 @@
    "name": "@zui/progress",
    "description": "ZUI progress",
    "version": "0.0.1",
-   "keywords": ["css", "zui:css-progress"],
+   "keywords": ["css", "zui:control"],
    "main": "src/main.ts",
    "module": "src/main.ts",
    "exports": {

--- a/lib/scrollbar/package.json
+++ b/lib/scrollbar/package.json
@@ -6,7 +6,7 @@
     "keywords": [
         "css",
         "js",
-        "zui:component"
+        "zui:control"
     ],
     "files": [
         "./src/**/*"

--- a/lib/search-box/package.json
+++ b/lib/search-box/package.json
@@ -5,7 +5,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "files": [
         "./src/**/*"

--- a/lib/sidebar/package.json
+++ b/lib/sidebar/package.json
@@ -8,6 +8,7 @@
         "./react": "./src/main-react.ts"
     },
     "browserslist": "",
+    "keywords": ["zui:component"],
     "files": [
         "./src/**/*"
     ],

--- a/lib/sortable/package.json
+++ b/lib/sortable/package.json
@@ -4,7 +4,7 @@
     "version": "0.0.1",
     "keywords": [
         "js",
-        "zui:js-lib"
+        "zui:js-helpers"
     ],
     "browser": "src/main.ts",
     "main": "src/main.ts",

--- a/lib/split/package.json
+++ b/lib/split/package.json
@@ -3,6 +3,7 @@
     "description": "split.js plugin from https://split.js.org/",
     "version": "0.0.1",
     "browser": "src/main.ts",
+    "keywords": ["zui:js-helpers"],
     "main": "src/main.ts",
     "files": [
         "./src/**/*"

--- a/lib/store/package.json
+++ b/lib/store/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/store",
     "description": "ZUI localstorage helper",
     "version": "0.0.1",
-    "keywords": ["js", "zui:js-lib"],
+    "keywords": ["js", "zui:js-helpers"],
     "browser": "src/main.ts",
     "main": "src/main.ts",
     "files": [

--- a/lib/table/package.json
+++ b/lib/table/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/table",
     "description": "ZUI table",
     "version": "0.0.1",
-    "keywords": ["css", "js", "components"],
+    "keywords": ["css", "js", "components", "zui:component"],
     "main": "src/main.ts",
     "devDependencies": {
         "@zui/base": "workspace:*",

--- a/lib/tabs/package.json
+++ b/lib/tabs/package.json
@@ -6,7 +6,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:js-ui"
     ],
     "files": [
         "./src/**/*"

--- a/lib/time-span/package.json
+++ b/lib/time-span/package.json
@@ -6,7 +6,7 @@
     "keywords": [
         "css",
         "js",
-        "zui:component"
+        "zui:control"
     ],
     "files": [
         "./src/**/*"

--- a/lib/toolbar/package.json
+++ b/lib/toolbar/package.json
@@ -2,7 +2,7 @@
     "name": "@zui/toolbar",
     "description": "ZUI Toolbar",
     "version": "0.0.1",
-    "keywords": ["css", "components"],
+    "keywords": ["css", "components", "zui:component"],
     "main": "src/main.ts",
     "devDependencies": {
         "@zui/avatar": "workspace:^0.0.1",

--- a/lib/tree/package.json
+++ b/lib/tree/package.json
@@ -5,7 +5,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "files": [
         "./src/**/*"

--- a/lib/typography/package.json
+++ b/lib/typography/package.json
@@ -4,6 +4,7 @@
     "main": "src/main.ts",
     "browser": "src/main.ts",
     "browserslist": "",
+    "keywords": ["zui:css-base"],
     "files": [
         "./src/**/*"
     ],

--- a/lib/upload-imgs/package.json
+++ b/lib/upload-imgs/package.json
@@ -10,7 +10,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "dependencies": {
         "@zui/button": "workspace:^0.0.1",

--- a/lib/upload/package.json
+++ b/lib/upload/package.json
@@ -10,7 +10,7 @@
     "browserslist": "",
     "keywords": [
         "css",
-        "zui:control"
+        "zui:component"
     ],
     "dependencies": {
         "@zui/button": "workspace:^0.0.1",

--- a/lib/virtual-grid/package.json
+++ b/lib/virtual-grid/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@zui/virtual-grid",
     "version": "0.0.1",
+    "keywords": ["zui:component"],
     "main": "src/main.ts",
     "exports": {
         ".": "./src/main.ts",

--- a/lib/virtualize/package.json
+++ b/lib/virtualize/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@zui/virtualize",
     "version": "0.0.1",
+    "keywords": ["zui:component"],
     "main": "src/main.ts",
     "exports": {
         ".": "./src/main.ts",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "docs:serve": "cd docs && pnpm serve",
     "docs:prepare": "tsx ./scripts/docs/prepare.ts",
     "extend-lib": "tsx ./scripts/libs/extend-lib.ts",
+    "lib:keywords": "tsx ./scripts/libs/check-keywords.ts",
     "publish:npm": "pnpm build -- --ignoreNotReady && tsx ./scripts/build/publish.ts && cd ./publish && npm publish"
   },
   "dependencies": {

--- a/scripts/libs/check-keywords.ts
+++ b/scripts/libs/check-keywords.ts
@@ -1,0 +1,204 @@
+import Path from 'path';
+import {fileURLToPath} from 'url';
+import fs from 'fs-extra';
+import {libTypeOrders} from './lib-type';
+
+/**
+ * Every lib manifest carries exactly one `zui:<type>` keyword, derived from its
+ * `zui.type`. The field feeds no build or dev behaviour today — `scripts/libs/query.ts`
+ * groups and orders libs from `zui.type` alone — so nothing keeps the two in step on
+ * its own, which is how 52 of 65 manifests came to disagree with their own type.
+ *
+ * This module is both the generator and the guard: `checkLibKeywords` is pure and is
+ * what `tests/unit/lib-keywords.test.ts` asserts on, and `--fix` is the same check with
+ * writes enabled. They cannot drift apart because there is only one rule.
+ *
+ * Free-form keywords (`css`, `js`, `components`) are out of scope: the rule neither adds
+ * nor removes them, and does not judge whether they are accurate.
+ */
+
+export const ZUI_KEYWORD_PREFIX = 'zui:';
+
+export type LibKeywordsIssue
+    = | 'invalid-type'
+        | 'missing-field'
+        | 'missing-entry'
+        | 'wrong-entry'
+        | 'duplicate-entry';
+
+export interface LibManifestInfo {
+    /** Directory name under `lib/`. */
+    lib: string;
+    /** Absolute path to the manifest. */
+    file: string;
+    /** Value of `zui.type`, if the manifest declares one. */
+    type?: string;
+    /** Value of `keywords`, or undefined when the field is absent. */
+    keywords?: string[];
+}
+
+export interface LibKeywordsViolation {
+    lib: string;
+    file: string;
+    issue: LibKeywordsIssue;
+    /** The `zui:<type>` entry the manifest should carry, or '' when the type is unusable. */
+    expected: string;
+    /** The `zui:` entries the manifest actually carries. */
+    actual: string[];
+    message: string;
+    /** False when the violation needs a human — an unusable `zui.type`. */
+    fixable: boolean;
+}
+
+/** Read every built-in lib manifest. Exts are deliberately excluded: they are gitignored and absent on CI. */
+export function readLibManifests(libsPath: string): LibManifestInfo[] {
+    return fs.readdirSync(libsPath)
+        .filter(lib => fs.existsSync(Path.join(libsPath, lib, 'package.json')))
+        .sort()
+        .map((lib) => {
+            const file = Path.join(libsPath, lib, 'package.json');
+            const manifest = fs.readJSONSync(file) as {keywords?: string[]; zui?: {type?: string}};
+            return {lib, file, type: manifest.zui?.type, keywords: manifest.keywords};
+        });
+}
+
+export function checkLibKeywords(manifests: LibManifestInfo[]): LibKeywordsViolation[] {
+    const violations: LibKeywordsViolation[] = [];
+    for (const {lib, file, type, keywords} of manifests) {
+        const actual = (keywords ?? []).filter(keyword => keyword.startsWith(ZUI_KEYWORD_PREFIX));
+
+        if (!type || libTypeOrders[type as keyof typeof libTypeOrders] === undefined) {
+            violations.push({
+                lib, file, issue: 'invalid-type', expected: '', actual, fixable: false,
+                message: `zui.type is ${type ? `"${type}", which is not a known lib type` : 'missing'}`,
+            });
+            continue;
+        }
+
+        const expected = `${ZUI_KEYWORD_PREFIX}${type}`;
+        const base = {lib, file, expected, actual, fixable: true};
+
+        if (keywords === undefined) {
+            violations.push({...base, issue: 'missing-field', message: `no keywords field; expected ["${expected}"]`});
+        } else if (!actual.length) {
+            violations.push({...base, issue: 'missing-entry', message: `no zui: entry; expected "${expected}"`});
+        } else if (actual.length > 1) {
+            violations.push({...base, issue: 'duplicate-entry', message: `${actual.length} zui: entries (${actual.join(', ')}); expected only "${expected}"`});
+        } else if (actual[0] !== expected) {
+            violations.push({...base, issue: 'wrong-entry', message: `has "${actual[0]}" but zui.type is "${type}"; expected "${expected}"`});
+        }
+    }
+    return violations;
+}
+
+/**
+ * Where a missing `keywords` field is inserted. The repo has no single key order, but
+ * every manifest carries at least one of these, and `keywords` follows `browserslist`
+ * or `version` in all 50 manifests that already declare it.
+ */
+const INSERT_AFTER_KEYS = ['browserslist', 'browser', 'version', 'name'];
+
+function findKeywordsSpan(text: string): {start: number; end: number} | undefined {
+    const match = /"keywords"\s*:\s*\[/.exec(text);
+    if (!match) {
+        return undefined;
+    }
+    const end = text.indexOf(']', match.index + match[0].length);
+    return end < 0 ? undefined : {start: match.index, end: end + 1};
+}
+
+/**
+ * Rewrite one manifest's `keywords` so it carries exactly the expected `zui:` entry.
+ * Edits the text in place rather than re-serializing the manifest: a JSON round-trip
+ * expands the inline arrays this repo uses and turns a one-line diff into a whole-file
+ * rewrite.
+ */
+export function fixManifestKeywords(text: string, violation: LibKeywordsViolation): string {
+    const {expected} = violation;
+    const eol = text.includes('\r\n') ? '\r\n' : '\n';
+    const span = findKeywordsSpan(text);
+
+    if (!span) {
+        const lines = text.split(eol);
+        const anchor = INSERT_AFTER_KEYS
+            .map(key => lines.findIndex(line => new RegExp(`^\\s*"${key}"\\s*:`).test(line)))
+            .find(index => index >= 0);
+        if (anchor === undefined) {
+            throw new Error(`Cannot place keywords in ${violation.file}: none of ${INSERT_AFTER_KEYS.join(', ')} found`);
+        }
+        const indent = /^\s*/.exec(lines[anchor])![0];
+        lines.splice(anchor + 1, 0, `${indent}"keywords": [${JSON.stringify(expected)}],`);
+        return lines.join(eol);
+    }
+
+    const source = text.slice(span.start, span.end);
+    const entries: string[] = JSON.parse(source.slice(source.indexOf('[')));
+    const kept = entries.filter(entry => !entry.startsWith(ZUI_KEYWORD_PREFIX));
+    const at = entries.findIndex(entry => entry.startsWith(ZUI_KEYWORD_PREFIX));
+    // Keep the zui: entry where it already sat; append it when the manifest had none.
+    kept.splice(at < 0 ? kept.length : Math.min(at, kept.length), 0, expected);
+
+    const multiline = source.includes('\n');
+    if (!multiline) {
+        return `${text.slice(0, span.start)}"keywords": [${kept.map(entry => JSON.stringify(entry)).join(', ')}]${text.slice(span.end)}`;
+    }
+    const indent = /^\s*/.exec(text.slice(text.lastIndexOf(eol, span.start) + eol.length))![0];
+    const inner = kept.map(entry => `${indent}    ${JSON.stringify(entry)}`).join(`,${eol}`);
+    return `${text.slice(0, span.start)}"keywords": [${eol}${inner}${eol}${indent}]${text.slice(span.end)}`;
+}
+
+export function fixLibKeywords(violations: LibKeywordsViolation[]): string[] {
+    const fixed: string[] = [];
+    for (const violation of violations) {
+        if (!violation.fixable) {
+            continue;
+        }
+        const text = fs.readFileSync(violation.file, 'utf8');
+        const next = fixManifestKeywords(text, violation);
+        if (next !== text) {
+            fs.writeFileSync(violation.file, next);
+            fixed.push(violation.lib);
+        }
+    }
+    return fixed;
+}
+
+async function runCli() {
+    const rootPath = Path.resolve(fileURLToPath(import.meta.url), '../../..');
+    const libsPath = Path.join(rootPath, 'lib');
+    const fix = process.argv.includes('--fix');
+
+    const manifests = readLibManifests(libsPath);
+    const violations = checkLibKeywords(manifests);
+
+    if (!violations.length) {
+        console.log(`All ${manifests.length} lib manifests carry the right zui: keyword.`);
+        return;
+    }
+
+    for (const violation of violations) {
+        console.log(`${violation.lib}: ${violation.message}`);
+    }
+
+    if (!fix) {
+        console.log(`\n${violations.length} of ${manifests.length} manifests need fixing. Re-run with --fix.`);
+        process.exitCode = 1;
+        return;
+    }
+
+    const fixed = fixLibKeywords(violations);
+    console.log(`\nFixed ${fixed.length} of ${violations.length} manifests.`);
+
+    const remaining = checkLibKeywords(readLibManifests(libsPath));
+    if (remaining.length) {
+        console.log(`${remaining.length} still failing:`);
+        for (const violation of remaining) {
+            console.log(`  ${violation.lib}: ${violation.message}`);
+        }
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === Path.resolve(process.argv[1])) {
+    await runCli();
+}

--- a/tests/unit/lib-keywords.test.ts
+++ b/tests/unit/lib-keywords.test.ts
@@ -1,0 +1,101 @@
+import Path from 'path';
+import {fileURLToPath} from 'url';
+import {describe, expect, it} from 'vitest';
+import {checkLibKeywords, fixManifestKeywords, readLibManifests, type LibKeywordsIssue, type LibManifestInfo} from '../../scripts/libs/check-keywords';
+
+const rootPath = Path.resolve(fileURLToPath(import.meta.url), '../../..');
+const libsPath = Path.join(rootPath, 'lib');
+
+function manifest(over: Partial<LibManifestInfo> = {}): LibManifestInfo {
+    return {lib: 'demo', file: '/lib/demo/package.json', type: 'component', keywords: ['css', 'zui:component'], ...over};
+}
+
+describe('lib keywords', () => {
+    it('every lib manifest carries exactly one zui: keyword matching its zui.type', () => {
+        const manifests = readLibManifests(libsPath);
+        expect(manifests.length).toBeGreaterThan(0);
+
+        const violations = checkLibKeywords(manifests);
+        // Named so a failure reports which libs drifted, not just a count.
+        expect(violations.map(violation => `${violation.lib}: ${violation.message}`)).toEqual([]);
+    });
+
+    describe('checkLibKeywords', () => {
+        it('accepts a manifest whose zui: entry matches its type', () => {
+            expect(checkLibKeywords([manifest()])).toEqual([]);
+        });
+
+        it('ignores free-form keywords entirely', () => {
+            expect(checkLibKeywords([manifest({keywords: ['css', 'js', 'components', 'zui:component']})])).toEqual([]);
+        });
+
+        it.each<[LibKeywordsIssue, Partial<LibManifestInfo>]>([
+            ['missing-field', {keywords: undefined}],
+            ['missing-entry', {keywords: ['css']}],
+            ['wrong-entry', {keywords: ['css', 'zui:control']}],
+            ['duplicate-entry', {keywords: ['zui:component', 'zui:control']}],
+        ])('reports %s', (issue, over) => {
+            const violations = checkLibKeywords([manifest(over)]);
+            expect(violations).toHaveLength(1);
+            expect(violations[0].issue).toBe(issue);
+            expect(violations[0].expected).toBe('zui:component');
+        });
+
+        it.each([undefined, 'not-a-type'])('reports an unusable zui.type (%s) as unfixable', (type) => {
+            const violations = checkLibKeywords([manifest({type})]);
+            expect(violations).toHaveLength(1);
+            expect(violations[0].issue).toBe('invalid-type');
+            expect(violations[0].fixable).toBe(false);
+        });
+    });
+
+    describe('fixManifestKeywords', () => {
+        const fix = (text: string, over: Partial<LibManifestInfo> = {}) => {
+            const [violation] = checkLibKeywords([manifest(over)]);
+            return fixManifestKeywords(text, violation);
+        };
+
+        it('swaps a wrong entry in place, keeping the array inline and the order intact', () => {
+            const text = '{\n    "name": "@zui/demo",\n    "keywords": ["css", "zui:control", "js"],\n    "main": "src/main.ts"\n}\n';
+            expect(fix(text, {keywords: ['css', 'zui:control', 'js']}))
+                .toBe('{\n    "name": "@zui/demo",\n    "keywords": ["css", "zui:component", "js"],\n    "main": "src/main.ts"\n}\n');
+        });
+
+        it('appends a missing entry after the free-form keywords', () => {
+            const text = '{\n    "keywords": ["css", "components"]\n}\n';
+            expect(fix(text, {keywords: ['css', 'components']}))
+                .toBe('{\n    "keywords": ["css", "components", "zui:component"]\n}\n');
+        });
+
+        it('collapses duplicate entries to one', () => {
+            const text = '{\n    "keywords": ["zui:component", "css", "zui:control"]\n}\n';
+            expect(fix(text, {keywords: ['zui:component', 'css', 'zui:control']}))
+                .toBe('{\n    "keywords": ["zui:component", "css"]\n}\n');
+        });
+
+        it('inserts a missing field after browserslist', () => {
+            const text = '{\n    "version": "0.0.1",\n    "browserslist": "",\n    "main": "src/main.ts"\n}\n';
+            expect(fix(text, {keywords: undefined}))
+                .toBe('{\n    "version": "0.0.1",\n    "browserslist": "",\n    "keywords": ["zui:component"],\n    "main": "src/main.ts"\n}\n');
+        });
+
+        it('falls back to version when there is no browserslist or browser', () => {
+            const text = '{\n    "name": "@zui/demo",\n    "version": "0.0.1",\n    "main": "src/main.ts"\n}\n';
+            expect(fix(text, {keywords: undefined}))
+                .toBe('{\n    "name": "@zui/demo",\n    "version": "0.0.1",\n    "keywords": ["zui:component"],\n    "main": "src/main.ts"\n}\n');
+        });
+
+        it('preserves a multi-line array and CRLF line endings', () => {
+            const text = '{\r\n    "keywords": [\r\n        "css",\r\n        "zui:control"\r\n    ]\r\n}\r\n';
+            expect(fix(text, {keywords: ['css', 'zui:control']}))
+                .toBe('{\r\n    "keywords": [\r\n        "css",\r\n        "zui:component"\r\n    ]\r\n}\r\n');
+        });
+
+        it('is idempotent', () => {
+            const text = '{\n    "keywords": ["css", "zui:control"]\n}\n';
+            const once = fix(text, {keywords: ['css', 'zui:control']});
+            expect(checkLibKeywords([manifest({keywords: ['css', 'zui:component']})])).toEqual([]);
+            expect(once).toBe('{\n    "keywords": ["css", "zui:component"]\n}\n');
+        });
+    });
+});


### PR DESCRIPTION
52 of 65 lib manifests disagreed with their own `zui.type`. This fixes them and adds a
guard so they cannot drift again.

## The state before

| Group | n |
| --- | --- |
| `zui:` entry naming a different type | 29 |
| `keywords` present, no `zui:` entry | 8 |
| no `keywords` field at all | 15 |
| consistent | 13 |

Two of the 29 were not drift but one-off strings matching no type at all: `progress` said
`zui:css-progress` and `progress-circle` said `zui:js-progress-circle`.

## Why guard rather than just fix

**`keywords` is read by nothing in this repo.** `scripts/libs/query.ts:106-137` groups and
orders libs from `zui.type` alone, and the field appears nowhere in `scripts/`,
`vite.config.ts` or `tailwind.config.cjs`. That is precisely why it drifted — nothing was
holding it in step, so fixing it once only resets the clock.

Deleting the field would have been equally defensible. Keeping it and deriving it means
the metadata stays true without anyone having to remember it.

## Design

`scripts/libs/check-keywords.ts` is one rule with writes optionally enabled, so the
generator and the guard cannot disagree:

- `checkLibKeywords(manifests)` is pure and returns violations.
- `--fix` is that same check applied, then re-run to confirm it converged.
- `pnpm lib:keywords` checks; `pnpm lib:keywords --fix` rewrites.

`tests/unit/lib-keywords.test.ts` asserts zero violations across every manifest under
`lib/`, comparing violation *messages* rather than a count so a failure names the libs
that drifted. It sits in the existing `unit` project, so `pnpm check` already runs it with
no script changes. Exts are excluded from the scan — they are gitignored and absent on CI,
so including them would make the result depend on the machine.

## Scope of the rule

The `zui:` entry only. Free-form keywords (`css`, `js`, `components`) are left exactly as
they are, in order, and an existing `zui:` entry keeps its position. `lib/table` claims
`js` while shipping none — out of scope here, and left alone rather than quietly changed.

## Commit order

The manifest churn comes **first**, the tooling second, so every commit in the series
passes `pnpm check`. Rule-first would leave one commit red for `git bisect`.

## Verification

- **Both directions.** Corrupting `lib/panel`'s entry to `zui:control` fails the test with
  a message naming `panel`; `--fix` restores the file byte-identically.
- **Idempotent.** A second `--fix` reports all 65 clean and produces no further diff.
- **Nothing but `keywords` moved.** Comparing each manifest against its parent shows 0
  changes to any other key and 0 changes to key order — checked programmatically.
- **No behaviour change**, confirmed rather than assumed: `pnpm build` output is identical
  across all 22 artifacts. The 20 CSS files are byte-identical; `zui.js` and `zui.esm.js`
  differ only in the embedded git hash and a wall-clock build stamp, which every build
  embeds regardless of this change.
- `pnpm check` green: 10 test files / 76 tests, up from 9 / 60.

Rebased onto `origin/dev_optimize` @ `68d7e165d7`. No file overlap with the six upstream
commits, and none with #243.
