### PR TITLE
* helpers: parse date-only strings as local midnight

### DIFF
--- a/lib/helpers/docs/lib/helpers/date-helper.md
+++ b/lib/helpers/docs/lib/helpers/date-helper.md
@@ -16,6 +16,10 @@ function createDate(dateLike: string | number | Date): Date;
 
 **返回值**：`Date`：日期时间对象。
 
+::: tip 提示
+形如 `2026-09-17` 的纯日期字符串会按**本地时区的零点**解析（`Date` 构造函数本身会把这种字符串当作 UTC 零点，在 UTC 以西的时区会得到前一天）。带时间的字符串和时间戳按 `Date` 构造函数的规则处理。
+:::
+
 :::
 
 ## `addDate`

--- a/lib/helpers/src/date-helper.ts
+++ b/lib/helpers/src/date-helper.ts
@@ -34,6 +34,12 @@ export const createDate = (date?: DateLike, forceNew?: boolean): Date => {
         date = date.trim();
         if (/^\d+$/.test(date)) {
             date = Number.parseInt(date, 10);
+        } else if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+            // The Date constructor treats a date-only ISO string ("2026-09-17") as UTC midnight, so in time zones
+            // west of UTC it becomes the previous day. Parse it as local midnight instead, consistent with
+            // "2026-09-17 00:00:00" and with what date pickers expect.
+            const [year, month, day] = date.split('-').map(Number);
+            return new Date(year, month - 1, day);
         }
     }
     if (typeof date === 'number' && date < 10000000000) {

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -47,6 +47,23 @@ describe('@zui/helpers', () => {
             expect(clone.getTime()).toBe(original.getTime());
         });
 
+        it('parses date-only ISO strings as local midnight in any time zone', () => {
+            const originalTZ = process.env.TZ;
+            try {
+                for (const tz of ['America/Edmonton', 'Asia/Shanghai', 'UTC']) {
+                    process.env.TZ = tz;
+                    const date = createDate('2026-09-17');
+                    expect([date.getFullYear(), date.getMonth(), date.getDate(), date.getHours()]).toEqual([2026, 8, 17, 0]);
+                    expect(formatDate('2026-09-17', 'yyyy-MM-dd')).toBe('2026-09-17');
+                    expect(formatDate(' 2026-09-17 ', 'yyyy-MM-dd')).toBe('2026-09-17');
+                }
+            } finally {
+                process.env.TZ = originalTZ;
+            }
+            expect(createDate('2026-09-17T00:00:00Z').getTime()).toBe(Date.UTC(2026, 8, 17));
+            expect(createDate('2026-09-17 10:30:00').getHours()).toBe(10);
+        });
+
         it('adds supported calendar units without mutating the input', () => {
             const original = new Date(2026, 0, 5, 10, 0, 0);
             expect(addDate(original, '2week').getDate()).toBe(19);


### PR DESCRIPTION
## 问题

`createDate('2026-09-17')` 把纯日期字符串直接交给 `Date` 构造函数，而按 ECMAScript 规范，`YYYY-MM-DD` 这种只有日期的 ISO 串会被当作 **UTC 零点**。在 UTC 以西的时区里这就是本地的前一天：

```js
// 浏览器时区 America/Edmonton (UTC-6)
zui.createDate('2026-09-17')                    // Wed Sep 16 2026 18:00:00 GMT-0600
zui.formatDate('2026-09-17', 'yyyy-MM-dd')     // "2026-09-16"
```

实际表现是日期选择器点 17 号，输入框里变成 16 号（在禅道 22.5 上复现，浏览器位于加拿大 Edmonton）。在 UTC+8 看不到这个问题，所以一直没被发现。

## 修改

- `createDate`：匹配 `^\d{4}-\d{2}-\d{2}$` 的字符串改为按**本地零点**构造（`new Date(year, month - 1, day)`），与 `YYYY-MM-DD HH:mm:ss` 已有的本地时间语义一致。带时间的字符串、时间戳、`Date` 对象的行为不变。
- 单元测试：在 `America/Edmonton`、`Asia/Shanghai`、`UTC` 三个时区下验证纯日期串得到当天零点，并覆盖带 `Z` 的 ISO 串和带时间的字符串不受影响。未修复时该用例在 Edmonton 时区失败（得到 `[2026, 8, 16, 18]`），修复后通过。
- 文档：`date-helper.md` 增加一条提示说明纯日期串按本地时区解析。

## 验证

- `pnpm exec vitest run tests/unit/helpers.test.ts`：15 passed
- `pnpm exec eslint` 对改动文件无告警；`pnpm typecheck` 通过

---

**Summary (EN):** `createDate()` passed date-only ISO strings to the `Date` constructor, which parses them as UTC midnight; in time zones west of UTC that is the previous local day, so date pickers showed the day before the one the user picked. Parse `YYYY-MM-DD` as local midnight instead; strings with a time part, timestamps and `Date` objects are unchanged. Adds a multi-time-zone unit test and a docs note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
